### PR TITLE
| needs to be escaped

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A webpack plugin for [prepack](https://prepack.io/).
 
 |Name|Description|Default|
 |---|---|---|
-|`test`|A regex used to match the files.|`/\.js($|\?)/i`|
+|`test`|A regex used to match the files.|`/\.js($\|\?)/i`|
 |`prepack`|Prepack configuration. See [Prepack documentation](https://prepack.io/getting-started.html#options).|
 
 ## Example


### PR DESCRIPTION
| breaks to the next table column. Needed to be escaped.