### PR TITLE
docs: add note that plugin works only with webpack2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A webpack plugin for [prepack](https://prepack.io/).
 1. Install `prepack-webpack-plugin`.
 1. Add an instance of the plugin to the webpack [plugin configuration](https://webpack.js.org/configuration/plugins/).
 
+> Note that this plugin only works with **webpack 2.x**
+
 ### Configuration
 
 |Name|Description|Default|


### PR DESCRIPTION
Since it looks like I am not the only who came across the `chunk.hasRuntime is not a function` issue ([#18](https://github.com/gajus/prepack-webpack-plugin/issues/18)), adding a note in **Usage** would make it more clear for anyone who wants to use this plugin that this plugin only works with webpack2.x